### PR TITLE
Check the status code returned from slack 

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -50,7 +51,7 @@ func sendToSlack(message SlackMessage) error {
 		}
 		bodyString := string(bodyBytes)
 
-		log.Printf("Error sending message to slack. StatusCode: %d. Resp: %s", resp.StatusCode, bodyString)
+		return fmt.Errorf("error sending message to slack. status code: %d. resp: %s", resp.StatusCode, bodyString)
 	}
 
 	return nil


### PR DESCRIPTION
This is to make sure it is a successful code. Otherwise we log the status code and error message returned in the body. Checking if err is nil does not always help as the post request might work, but the server is not happy with the request.